### PR TITLE
Support python 3.4 by backporting math.inf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ sudo: false
 
 matrix:
   include:
+  - python: "3.4"
   - python: "3.5"
   - python: "3.6"
 

--- a/pyerf/pyerf.py
+++ b/pyerf/pyerf.py
@@ -20,6 +20,11 @@ PI = 3.141592653589793      # cause I don't want to import numpy.
 erf = math.erf
 erfc = math.erfc
 
+try:
+    from math import inf
+except ImportError:
+    inf = float('inf')
+
 # ---------------------------------------------------------------------------
 ### Functions
 # ---------------------------------------------------------------------------
@@ -199,7 +204,7 @@ def erfinv(z):
     if z == 0:
         return 0
     if z == 1:
-        return math.inf
+        return inf
     if z == -1:
-        return -math.inf
+        return -inf
     return _ndtri((z + 1) / 2.0) / math.sqrt(2)

--- a/pyerf/tests/test_pyerf.py
+++ b/pyerf/tests/test_pyerf.py
@@ -8,8 +8,10 @@ Created by Douglas Thor on 2017-02-22 16:08:02 UTC.
 ### Imports
 # ---------------------------------------------------------------------------
 # Standard Library
-import os
-import math
+try:
+    from math import inf
+except ImportError:
+    inf = float('inf')
 
 
 # Third-Party
@@ -78,6 +80,6 @@ class TestErfInv(object):
         assert np.allclose(y, sp.erfinv(x))
 
     def test_erfinv_extremes(self):
-        assert pyerf.erfinv(1) == math.inf
-        assert pyerf.erfinv(-1) == -math.inf
+        assert pyerf.erfinv(1) == inf
+        assert pyerf.erfinv(-1) == -inf
         assert pyerf.erfinv(0) == 0

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Topic :: Scientific/Engineering :: Mathematics",


### PR DESCRIPTION
Tries to import `math.inf` and if it fails, sets it to `float('inf')`.

Also adds travis builds for py34 and updates the pypi trove classifiers.