### PR TITLE
Add erf backport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ sudo: false
 matrix:
   include:
   - python: "2.7"
-  - python: "3.2"
   - python: "3.3"
   - python: "3.4"
   - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ sudo: false
 
 matrix:
   include:
+  - python: "2.7"
+  - python: "3.2"
+  - python: "3.3"
   - python: "3.4"
   - python: "3.5"
   - python: "3.6"

--- a/pyerf/pyerf.py
+++ b/pyerf/pyerf.py
@@ -21,14 +21,6 @@ PI = math.pi
 ROOT_2PI = math.sqrt(2 * PI)
 EXP_NEG2 = math.exp(-2)
 
-# bring the built-ins into this namespace for conveinence.
-try:
-    erf = math.erf
-    erfc = math.erfc
-except ImportError:
-    msg = "Python >= 3.2 is required for the math.erf and erfc functions."
-    raise ImportWarning(msg)
-
 # math.inf was added in Python 3.5.
 try:
     from math import inf
@@ -39,6 +31,127 @@ except ImportError:
 # ---------------------------------------------------------------------------
 ### Functions
 # ---------------------------------------------------------------------------
+def _erf(x):
+    """
+    Port of cephes ``ndtr.c`` ``erf`` function.
+
+    See https://github.com/jeremybarnes/cephes/blob/master/cprob/ndtr.c
+    """
+    T = [
+        9.60497373987051638749E0,
+        9.00260197203842689217E1,
+        2.23200534594684319226E3,
+        7.00332514112805075473E3,
+        5.55923013010394962768E4,
+    ]
+
+    U = [
+        3.35617141647503099647E1,
+        5.21357949780152679795E2,
+        4.59432382970980127987E3,
+        2.26290000613890934246E4,
+        4.92673942608635921086E4,
+    ]
+
+    # Shorcut special cases
+    if x == 0:
+        return 0
+    if x == inf:
+        return 1
+    if x == -inf:
+        return -1
+
+    if abs(x) > 1:
+        return 1 - erfc(x)
+
+    z = x * x
+    return x * _polevl(z, T, 4) / _p1evl(z, U, 5)
+
+
+def _erfc(a):
+    """
+    Port of cephes ``ndtr.c`` ``erfc`` function.
+
+    See https://github.com/jeremybarnes/cephes/blob/master/cprob/ndtr.c
+    """
+    # approximation for abs(a) < 8 and abs(a) >= 1
+    P = [
+        2.46196981473530512524E-10,
+        5.64189564831068821977E-1,
+        7.46321056442269912687E0,
+        4.86371970985681366614E1,
+        1.96520832956077098242E2,
+        5.26445194995477358631E2,
+        9.34528527171957607540E2,
+        1.02755188689515710272E3,
+        5.57535335369399327526E2,
+    ]
+
+    Q = [
+        1.32281951154744992508E1,
+        8.67072140885989742329E1,
+        3.54937778887819891062E2,
+        9.75708501743205489753E2,
+        1.82390916687909736289E3,
+        2.24633760818710981792E3,
+        1.65666309194161350182E3,
+        5.57535340817727675546E2,
+    ]
+
+    # approximation for abs(a) >= 8
+    R = [
+        5.64189583547755073984E-1,
+        1.27536670759978104416E0,
+        5.01905042251180477414E0,
+        6.16021097993053585195E0,
+        7.40974269950448939160E0,
+        2.97886665372100240670E0,
+    ]
+
+    S = [
+        2.26052863220117276590E0,
+        9.39603524938001434673E0,
+        1.20489539808096656605E1,
+        1.70814450747565897222E1,
+        9.60896809063285878198E0,
+        3.36907645100081516050E0,
+    ]
+
+    # Shortcut special cases
+    if a == 0:
+        return 1
+    if a == inf:
+        return 0
+    if a == -inf:
+        return 2
+
+    x = a
+    if a < 0:
+        x = -a
+
+    # computationally cheaper to calculate erf for small values, I guess.
+    if x < 1:
+        return 1 - erf(a)
+
+    z = -a * a
+
+    z = math.exp(z)
+
+    if x < 8:
+        p = _polevl(x, P, 8)
+        q = _p1evl(x, Q, 8)
+    else:
+        p = _polevl(x, R, 5)
+        q = _p1evl(x, S, 6)
+
+    y = (z * p) / q
+
+    if a < 0:
+        y = 2 - y
+
+    return y
+
+
 def _polevl(x, coefs, N):
     """
     Port of cephes ``polevl.c``.
@@ -223,3 +336,12 @@ def erfinv(z):
 
     # otherwise calculate things.
     return _ndtri((z + 1) / 2.0) / math.sqrt(2)
+
+
+# bring the built-ins into this namespace for conveinence.
+try:
+    erf = math.erf
+    erfc = math.erfc
+except ImportError:
+    erf = _erf
+    erfc = _erfc

--- a/pyerf/tests/test_pyerf.py
+++ b/pyerf/tests/test_pyerf.py
@@ -8,6 +8,7 @@ Created by Douglas Thor on 2017-02-22 16:08:02 UTC.
 ### Imports
 # ---------------------------------------------------------------------------
 # Standard Library
+import decimal
 try:
     from math import inf
 except ImportError:
@@ -35,6 +36,10 @@ from .. import pyerf
 # ---------------------------------------------------------------------------
 ### Helper Functions
 # ---------------------------------------------------------------------------
+def frange(x, y, jump):
+    while x < y:
+        yield float(x)
+        x += decimal.Decimal(jump)
 
 
 # ---------------------------------------------------------------------------
@@ -93,3 +98,113 @@ class TestErfInv(object):
         for val in values:
             with pytest.raises(ValueError):
                 pyerf.erfinv(val)
+
+
+class TestErf(object):
+    def test_erf_error(self):
+        # values from
+        # http://keisan.casio.com/exec/system/1180573449
+        known_values = (
+            (0.0001, 1.128379163334248694862E-4),
+            (0.001, 0.001128378790969236379948),
+            (0.01, 0.01128341555584961691591),
+            (0.02, 0.02256457469184494422437),
+            (0.05, 0.05637197779701662383127),
+            (0.1, 0.1124629160182848922033),
+            (0.3, 0.3286267594591274276389),
+            (0.5, 0.5204998778130465376827),
+            (0.7, 0.6778011938374184729756),
+            (0.9, 0.796908212422832128519),
+            (0.95, 0.8208908072732779419079),
+            (0.98, 0.8342315043402078805143),
+            (0.99, 0.8385080695553698035798),
+            (0.999, 0.8422852702064969420084),
+            (0.9999, 0.8426592780487594734183),
+            (1, 0.8427007929497148693412),
+            (2, 0.9953222650189527341621),
+            (3, 0.9999779095030014145586),
+            (4, 0.99999998458274209972),
+            (-1, -0.8427007929497148693412),
+            (-4, -0.99999998458274209972),
+        )
+
+        for x, expected in known_values:
+            result = pyerf.erf(x)
+            error = (expected - result) / result
+            assert abs(error) < 1e-10
+
+    def test_erf_extremes(self):
+        assert pyerf.erf(0) == 0
+        assert pyerf.erf(inf) == 1
+        assert pyerf.erf(-inf) == -1
+
+    @pytest.mark.skipif(not has_scipy, reason="Numpy or Scipy not installed")
+    def test_erf_error_vs_scipy(self):
+        x = np.arange(-4, 4, 0.0001)
+        N = len(x)
+
+        # Calculate the inverse of the error function
+        y = np.zeros(N)
+        for i in range(N):
+            y[i] = pyerf.erf(x[i])
+
+        assert np.allclose(y, sp.erf(x))
+
+
+class TestErfc(object):
+    def test_erfc_error(self):
+        # values from
+        # http://keisan.casio.com/exec/system/1180573449
+        known_values = (
+            (0.0001, 0.9998871620836665751305),
+            (0.001, 0.9988716212090307636201),
+            (0.01, 0.9887165844441503830841),
+            (0.02, 0.9774354253081550557756),
+            (0.05, 0.9436280222029833761687),
+            (0.1, 0.8875370839817151077967),
+            (0.3, 0.6713732405408725723611),
+            (0.5, 0.4795001221869534623173),
+            (0.7, 0.3221988061625815270244),
+            (0.9, 0.203091787577167871481),
+            (0.95, 0.1791091927267220580921),
+            (0.98, 0.1657684956597921194857),
+            (0.99, 0.1614919304446301964202),
+            (0.999, 0.1577147297935030579916),
+            (0.9999, 0.1573407219512405265817),
+            (1, 0.1572992070502851306588),
+            (2, 0.004677734981047265837931),
+            (3, 2.20904969985854413728E-5),
+            (4, 1.541725790028001885216E-8),
+            (-1, 1.842700792949714869341),
+            (-4, 1.99999998458274209972),
+        )
+
+        for x, expected in known_values:
+            result = pyerf.erfc(x)
+            error = (expected - result) / result
+            assert abs(error) < 1e-10
+
+    @pytest.mark.skipif(not has_scipy, reason="Numpy or Scipy not installed")
+    def test_erfc_error_vs_scipy(self):
+        x = np.arange(-4, 4, 0.0001)
+        N = len(x)
+
+        # Calculate the inverse of the error function
+        y = np.zeros(N)
+        for i in range(N):
+            y[i] = pyerf.erfc(x[i])
+
+        assert np.allclose(y, sp.erfc(x))
+
+
+class TestErfErfc(object):
+    def test_erf_erfc_complements(self):
+        data = frange(-4, 4, 0.001)
+
+        for x in data:
+            assert round(pyerf.erf(x) + pyerf.erfc(x), 10) == 1
+
+    def test_erfc_extremes(self):
+        assert pyerf.erfc(0) == 1
+        assert pyerf.erfc(inf) == 0
+        assert pyerf.erfc(-inf) == 2


### PR DESCRIPTION
Adds a backport of the `erf` and `erfc` functions which enables Py27 and Py33+ support.