### PR TITLE
Testing updates: property testing and force-no-math-stdlib

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+omit =
+    */tests/*
+    */__about__.py
+    */__init__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,21 @@ language: python
 
 sudo: false
 
+env:
+- SCIPY=true
+
 matrix:
   include:
   - python: "2.7"
   - python: "3.3"
+    env: SCIPY=false
   - python: "3.4"
   - python: "3.5"
   - python: "3.6"
   - python: "pypy"
+    env: SCIPY=false
   - python: "pypy3"
+    env: SCIPY=false
   allow_failures:
   - python: "pypy3"
 
@@ -27,6 +33,8 @@ install:
   # Start the install of everything
   - pip install --upgrade pip wheel
   - pip install -r requirements-dev.txt
+  # Install SciPy for most builds.
+  - if [ $SCIPY = true ]; then python -m pip install scipy==0.19.0; fi;
 
 script:
   - python -m pytest -v pyerf --cov=pyerf --cov-report term-missing --cov-config .coveragerc

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
   - python: "3.6"
   - python: "pypy"
   - python: "pypy3"
+  allow_failures:
+  - python: "pypy3"
 
 notifications:
   email: false
@@ -27,7 +29,7 @@ install:
   - pip install -r requirements-dev.txt
 
 script:
-  - python -m pytest -v pyerf
+  - python -m pytest -v pyerf --cov=pyerf --cov-report term-missing --cov-config .coveragerc
 
 deploy:
   provider: pypi

--- a/pyerf/pyerf.py
+++ b/pyerf/pyerf.py
@@ -26,6 +26,10 @@ except ImportError:
     inf = float('inf')
 
 
+#: Inputs above this value are considered infinity.
+MAXVAL = 1e50
+
+
 # ---------------------------------------------------------------------------
 ### Functions
 # ---------------------------------------------------------------------------
@@ -54,9 +58,9 @@ def _erf(x):
     # Shorcut special cases
     if x == 0:
         return 0
-    if x == inf:
+    if x >= MAXVAL:
         return 1
-    if x == -inf:
+    if x <= -MAXVAL:
         return -1
 
     if abs(x) > 1:
@@ -118,9 +122,9 @@ def _erfc(a):
     # Shortcut special cases
     if a == 0:
         return 1
-    if a == inf:
+    if a >= MAXVAL:
         return 0
-    if a == -inf:
+    if a <= -MAXVAL:
         return 2
 
     x = a
@@ -152,21 +156,24 @@ def _erfc(a):
 
 def _polevl(x, coefs, N):
     """
-    Port of cephes ``polevl.c``.
+    Port of cephes ``polevl.c``: evaluate polynomial
 
     See https://github.com/jeremybarnes/cephes/blob/master/cprob/polevl.c
     """
     ans = 0
     power = len(coefs) - 1
     for coef in coefs:
-        ans += coef * x**power
+        try:
+            ans += coef * x**power
+        except OverflowError:
+            pass
         power -= 1
     return ans
 
 
 def _p1evl(x, coefs, N):
     """
-    Port of cephes ``polevl.c``.
+    Port of cephes ``polevl.c``: evaluate polynomial, assuming coef[N] = 1
 
     See https://github.com/jeremybarnes/cephes/blob/master/cprob/polevl.c
     """
@@ -175,7 +182,7 @@ def _p1evl(x, coefs, N):
 
 def _ndtri(y):
     """
-    Port of cephes ``ndtri.c``
+    Port of cephes ``ndtri.c``: inverse normal distribution function.
 
     See https://github.com/jeremybarnes/cephes/blob/master/cprob/ndtri.c
     """
@@ -338,6 +345,7 @@ def erfinv(z):
 
 # bring the built-ins into this namespace for conveinence.
 try:
+    # math.erf and math.erfc were added in Python 3.2
     erf = math.erf
     erfc = math.erfc
 except ImportError:

--- a/pyerf/tests/test_pyerf.py
+++ b/pyerf/tests/test_pyerf.py
@@ -295,5 +295,44 @@ class TestErfErfInv(object):
 
     @given(st.floats(min_value=-4, max_value=4, allow_nan=False))
     def test_erfinv_erf_compliments(self, use_math_stdlib, x):
-        assume(abs(x) >= 1e-12)
-        assert pyerf.erfinv(pyerf.erf(x)) / x == pytest.approx(1)
+        assume(abs(x) >= 1e-300)
+        assert abs(pyerf.erfinv(pyerf.erf(x)) - x) <= abs(10 * x)
+
+
+class Test_PolEvl(object):
+    @given(st.floats(), st.lists(st.floats()), st.integers())
+    def test_exceptions(self, use_math_stdlib, x, coefs, N):
+        allowed_exceptions = (ValueError, )
+        try:
+            pyerf._polevl(x, coefs, N)
+        except allowed_exceptions:
+            pass
+        except Exception as err:
+            err_txt = "An unexpected exception was raised! {}".format(err)
+            raise AssertionError(err_txt)
+
+
+class Test_P1Evl(object):
+    @given(st.floats(), st.lists(st.floats()), st.integers())
+    def test_exceptions(self, use_math_stdlib, x, coefs, N):
+        allowed_exceptions = (ValueError, )
+        try:
+            pyerf._p1evl(x, coefs, N)
+        except allowed_exceptions:
+            pass
+        except Exception as err:
+            err_txt = "An unexpected exception was raised! {}".format(err)
+            raise AssertionError(err_txt)
+
+
+class Test_ndtri(object):
+    @given(st.floats())
+    def test_exceptions(self, use_math_stdlib, x):
+        allowed_exceptions = (ValueError, )
+        try:
+            pyerf._ndtri(x)
+        except allowed_exceptions:
+            pass
+        except Exception as err:
+            err_txt = "An unexpected exception was raised! {}".format(err)
+            raise AssertionError(err_txt)

--- a/pyerf/tests/test_pyerf.py
+++ b/pyerf/tests/test_pyerf.py
@@ -16,6 +16,9 @@ except ImportError:
 
 # Third-Party
 import pytest
+from hypothesis import assume
+from hypothesis import given
+from hypothesis import strategies as st
 
 has_scipy = True
 try:
@@ -40,6 +43,26 @@ def frange(x, y, jump):
     while x < y:
         yield float(x)
         x += decimal.Decimal(jump)
+
+
+@pytest.fixture(scope="module", params=[True, False])
+def use_math_stdlib(request):
+    # this 1st import is just to bring things into the namespace.
+    from .. import pyerf
+
+    # Delete the old pyerf module from our namespace because it might have
+    # been modified by this very function.
+    del pyerf
+    from .. import pyerf
+
+    # Are we using the `math` stdlib module?
+    if request.param:
+        # don't do anything special
+        pass
+    else:
+        # force pyerf to use the private methods
+        pyerf.erf = pyerf._erf
+        pyerf.erfc = pyerf._erfc
 
 
 # ---------------------------------------------------------------------------
@@ -99,6 +122,17 @@ class TestErfInv(object):
             with pytest.raises(ValueError):
                 pyerf.erfinv(val)
 
+    @given(st.floats())
+    def test_exceptions(self, x):
+        allowed_exceptions = (ValueError, )
+        try:
+            pyerf.erfinv(x)
+        except allowed_exceptions:
+            pass
+        except Exception as err:
+            err_txt = "An unexpected exception was raised! {}".format(err)
+            raise AssertionError(err_txt)
+
 
 class TestErf(object):
     def test_erf_error(self):
@@ -133,13 +167,13 @@ class TestErf(object):
             error = (expected - result) / result
             assert abs(error) < 1e-10
 
-    def test_erf_extremes(self):
+    def test_erf_extremes(self, use_math_stdlib):
         assert pyerf.erf(0) == 0
         assert pyerf.erf(inf) == 1
         assert pyerf.erf(-inf) == -1
 
     @pytest.mark.skipif(not has_scipy, reason="Numpy or Scipy not installed")
-    def test_erf_error_vs_scipy(self):
+    def test_erf_error_vs_scipy(self, use_math_stdlib):
         x = np.arange(-4, 4, 0.0001)
         N = len(x)
 
@@ -149,6 +183,26 @@ class TestErf(object):
             y[i] = pyerf.erf(x[i])
 
         assert np.allclose(y, sp.erf(x))
+
+    @given(st.floats())
+    def test_exceptions(self, use_math_stdlib, x):
+        allowed_exceptions = (ValueError, )
+        try:
+            pyerf.erf(x)
+        except allowed_exceptions:
+            pass
+        except Exception as err:
+            err_txt = "An unexpected exception was raised! {}".format(err)
+            raise AssertionError(err_txt)
+
+    @given(st.floats(allow_nan=False))
+    def test_result_always_between_plus_minus_one(self, use_math_stdlib, x):
+        assume(abs(x) <= 1e300)
+        import platform
+        if platform.python_implementation() == "PyPy":
+            assume(abs(x) < 1e100)
+        assert pyerf.erf(x) <= 1
+        assert pyerf.erf(x) >= -1
 
 
 class TestErfc(object):
@@ -185,7 +239,7 @@ class TestErfc(object):
             assert abs(error) < 1e-10
 
     @pytest.mark.skipif(not has_scipy, reason="Numpy or Scipy not installed")
-    def test_erfc_error_vs_scipy(self):
+    def test_erfc_error_vs_scipy(self, use_math_stdlib):
         x = np.arange(-4, 4, 0.0001)
         N = len(x)
 
@@ -196,15 +250,44 @@ class TestErfc(object):
 
         assert np.allclose(y, sp.erfc(x))
 
+    @given(st.floats())
+    def test_exceptions(self, use_math_stdlib, x):
+        allowed_exceptions = (ValueError, )
+        try:
+            pyerf.erfc(x)
+        except allowed_exceptions:
+            pass
+        except Exception as err:
+            err_txt = "An unexpected exception was raised! {}".format(err)
+            raise AssertionError(err_txt)
+
+    def test_erfc_extremes(self, use_math_stdlib):
+        assert pyerf.erfc(0) == 1
+        assert pyerf.erfc(inf) == 0
+        assert pyerf.erfc(-inf) == 2
+
+    @given(st.floats(allow_nan=False))
+    def test_result_always_between_zero_and_two(self, use_math_stdlib, x):
+        assume(abs(x) <= 1e100)
+        assert pyerf.erfc(x) <= 2
+        assert pyerf.erfc(x) >= 0
+
 
 class TestErfErfc(object):
-    def test_erf_erfc_complements(self):
+    def test_erf_erfc_complements(self, use_math_stdlib):
         data = frange(-4, 4, 0.001)
 
         for x in data:
             assert round(pyerf.erf(x) + pyerf.erfc(x), 10) == 1
 
-    def test_erfc_extremes(self):
-        assert pyerf.erfc(0) == 1
-        assert pyerf.erfc(inf) == 0
-        assert pyerf.erfc(-inf) == 2
+
+class TestErfErfInv(object):
+    @given(st.floats(min_value=-1, max_value=1, allow_nan=False))
+    def test_erf_erfinv_compliments(self, use_math_stdlib, x):
+        assume(abs(x) <= 0.99999999)
+        assert pyerf.erf(pyerf.erfinv(x)) == pytest.approx(x)
+
+    @given(st.floats(min_value=-4, max_value=4, allow_nan=False))
+    def test_erfinv_erf_compliments(self, use_math_stdlib, x):
+        assume(abs(x) >= 1e-12)
+        assert pyerf.erfinv(pyerf.erf(x)) / x == pytest.approx(1)

--- a/pyerf/tests/test_pyerf.py
+++ b/pyerf/tests/test_pyerf.py
@@ -9,6 +9,7 @@ Created by Douglas Thor on 2017-02-22 16:08:02 UTC.
 # ---------------------------------------------------------------------------
 # Standard Library
 import decimal
+import os
 try:
     from math import inf
 except ImportError:
@@ -18,6 +19,7 @@ except ImportError:
 import pytest
 from hypothesis import assume
 from hypothesis import given
+from hypothesis import settings
 from hypothesis import strategies as st
 
 has_scipy = True
@@ -32,8 +34,12 @@ from .. import pyerf
 
 
 # ---------------------------------------------------------------------------
-### Constants
+### Constants and Setup
 # ---------------------------------------------------------------------------
+# Create a profile for testing on CI (Travis, GitLab, etc.)
+settings.register_profile('ci', settings(max_examples=1000))
+if os.getenv('CI', None) is not None:
+    settings.load_profile('ci')
 
 
 # ---------------------------------------------------------------------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 pytest
+pytest-cov
 sphinx
+hypothesis

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest
-pytest-cov
-sphinx
-hypothesis
+pytest == 3.1.2
+pytest-cov == 2.5.1
+sphinx == 1.6.2
+hypothesis == 3.11.6


### PR DESCRIPTION
Updates to unit testing.

+ adds property testing via [hypothesis](https://hypothesis.readthedocs.io/en/latest/).
+ forces tests to use the private functions that `pyerf` defines in addition to those in `math` stdlib module.
+ most travis builds will now also run the SciPy tests.
+ Coverage is run on everything.
+ Fix potential bugs found by property testing.
+ Pin requirements for dev.